### PR TITLE
Refactor: Remove longitude_offset and radius from Grid constructor

### DIFF
--- a/baroclinic_instability.py
+++ b/baroclinic_instability.py
@@ -178,7 +178,7 @@ def baroclinic_perturbation_jw(
 
 
 layers = 12
-grid = di.Grid(longitude_wavenumbers=22, total_wavenumbers=23, longitude_nodes=64, latitude_nodes=32, longitude_offset=0.0, radius=None)
+grid = di.Grid(longitude_wavenumbers=22, total_wavenumbers=23, longitude_nodes=64, latitude_nodes=32)
 vertical_grid = di.SigmaCoordinates.equidistant(layers)
 coords = di.CoordinateSystem(grid, vertical_grid)
 initial_state_fn, aux_features = steady_state_jw(coords)

--- a/di.py
+++ b/di.py
@@ -368,12 +368,9 @@ class Grid:
     total_wavenumbers: int
     longitude_nodes: int
     latitude_nodes: int
-    longitude_offset: float
-    radius: float | None
 
     def __post_init__(self):
-        if self.radius is None:
-            object.__setattr__(self, "radius", 1.0)
+        pass
 
     @functools.cached_property
     def spherical_harmonics(self):
@@ -389,7 +386,7 @@ class Grid:
     @functools.cached_property
     def nodal_axes(self):
         lon, sin_lat = self.spherical_harmonics.nodal_axes
-        return lon + self.longitude_offset, sin_lat
+        return lon + 0.0, sin_lat
 
     @functools.cached_property
     def nodal_shape(self):
@@ -432,7 +429,7 @@ class Grid:
     @functools.cached_property
     def laplacian_eigenvalues(self):
         _, l = self.modal_axes
-        return -l * (l + 1) / (self.radius**2)
+        return -l * (l + 1) / (1.0**2)
 
     def to_nodal(self, x):
         f = self.spherical_harmonics.inverse_transform
@@ -490,8 +487,8 @@ class Grid:
         return x_lm1 + x_lp1
 
     def cos_lat_grad(self, x, clip: bool = True):
-        raw = self.d_dlon(x) / self.radius, self.cos_lat_d_dlat(
-            x) / self.radius
+        raw = self.d_dlon(x) / 1.0, self.cos_lat_d_dlat(
+            x) / 1.0
         if clip:
             return self.clip_wavenumbers(raw)
         return raw
@@ -505,7 +502,7 @@ class Grid:
         clip: bool = True,
     ):
         raw = (self.d_dlon(v[0]) +
-               self.sec_lat_d_dlat_cos2(v[1])) / self.radius
+               self.sec_lat_d_dlat_cos2(v[1])) / 1.0
         if clip:
             return self.clip_wavenumbers(raw)
         return raw
@@ -516,7 +513,7 @@ class Grid:
         clip: bool = True,
     ):
         raw = (self.d_dlon(v[1]) -
-               self.sec_lat_d_dlat_cos2(v[0])) / self.radius
+               self.sec_lat_d_dlat_cos2(v[0])) / 1.0
         if clip:
             return self.clip_wavenumbers(raw)
         return raw

--- a/held_suarez.py
+++ b/held_suarez.py
@@ -159,7 +159,7 @@ def isothermal_rest_atmosphere(
 
 layers = 24
 coords = di.CoordinateSystem(
-    horizontal=di.Grid(longitude_wavenumbers=22, total_wavenumbers=23, longitude_nodes=64, latitude_nodes=32, longitude_offset=0.0, radius=None),
+    horizontal=di.Grid(longitude_wavenumbers=22, total_wavenumbers=23, longitude_nodes=64, latitude_nodes=32),
     vertical=di.SigmaCoordinates.equidistant(layers),
 )
 p0 = 100e3 * units.pascal

--- a/weather_forecast_on_era5.py
+++ b/weather_forecast_on_era5.py
@@ -72,7 +72,7 @@ def slice_levels(output, level_indices):
 layers = 32
 ref_temp_si = 250 * units.degK
 model_coords = di.CoordinateSystem(
-    di.Grid(longitude_wavenumbers=171, total_wavenumbers=172, longitude_nodes=512, latitude_nodes=256, longitude_offset=0.0, radius=None),
+    di.Grid(longitude_wavenumbers=171, total_wavenumbers=172, longitude_nodes=512, latitude_nodes=256),
     di.SigmaCoordinates.equidistant(layers),
 )
 dt_si = 5 * units.minute


### PR DESCRIPTION
The longitude_offset and radius arguments to the Grid() constructor were always 0.0 and None (defaulting to 1.0) respectively in all three calls.

This commit removes these arguments from the Grid constructor and hardcodes the values in the relevant methods. The instantiations of Grid in baroclinic_instability.py, held_suarez.py, and weather_forecast_on_era5.py have been updated accordingly.